### PR TITLE
Move `docker-compose pull` up.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -19,6 +19,10 @@ function report_status() {
   fi
 }
 
+echo -e "\nPull images:"
+docker-compose pull
+report_status
+
 echo "Copy .env.sample to .env:"
 if [ ! -f .env ]
 then
@@ -40,10 +44,6 @@ then
 else
   echo -e "${GREEN}Personal secret key exists${NC}"
 fi
-
-echo -e "\nPull images:"
-docker-compose pull
-report_status
 
 echo -e "\nCreate database:"
 docker-compose run --rm backend ./bin/rake db:create


### PR DESCRIPTION
Using the default secret will cause `docker-compose run` executing before pulling the images:

```
if grep -Rq "$DEFAULT_SECRET" .env
then
  [HERE] secret=$(docker-compose run --rm --no-deps backend ./bin/rake secret)
  echo "$secret"
```

So the `docker-compose pull` block may need to be moved to the top?
