### PR TITLE
Fix wrong commands, support pass through arguments.

### DIFF
--- a/bin/restart
+++ b/bin/restart
@@ -1,3 +1,2 @@
 #!/bin/bash
-docker-compose down
-docker-compose up
+docker-compose restart $@

--- a/bin/start
+++ b/bin/start
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose up
+docker-compose up $@

--- a/bin/stop
+++ b/bin/stop
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose down
+docker-compose stop $@


### PR DESCRIPTION
There's a couple of things:

1. `docker-compose down` will `Stop and remove containers, networks, images, and volumes`. A better choice for stopping the `docker-compose start`ed service may be `docker-compose stop`.
2. To restart service, just use `docker-compose restart`.
3. `$@` in bash stores all arguments passed through the script. For example, people usually use `-d` with `docker-compose up` to run containers in the background. So add `$@` will be useful when running `bin/start -d`, just pass args to `docker-compose`.